### PR TITLE
Trust a leading <a> in a <li>

### DIFF
--- a/lib/middleman-hashicorp/hashicorp.rb
+++ b/lib/middleman-hashicorp/hashicorp.rb
@@ -24,7 +24,9 @@ module Middleman
       # @param [String] list_type
       #
       def list_item(text, list_type)
-        if md = text.match(/(<code>(.+?)<\/code>)/)
+        # If the <li> does not start with an anchor and includes a <code> tag,
+        # create an anchor with the contents of the code tag as its name.
+        if !text.match(/^<a\s+/) && md = text.match(/(<code>(.+?)<\/code>)/)
           container, name = md.captures
           anchor = anchor_for(name)
 

--- a/lib/middleman-hashicorp/hashicorp.rb
+++ b/lib/middleman-hashicorp/hashicorp.rb
@@ -26,7 +26,7 @@ module Middleman
       def list_item(text, list_type)
         # If the <li> does not start with an anchor and includes a <code> tag,
         # create an anchor with the contents of the code tag as its name.
-        if !text.match(/^<a\s+/) && md = text.match(/(<code>(.+?)<\/code>)/)
+        if !text.match(/^(<p>|)<a\s+/) && md = text.match(/(<code>(.+?)<\/code>)/)
           container, name = md.captures
           anchor = anchor_for(name)
 


### PR DESCRIPTION
Proposed fix for GH-6.  I tested with an unmodified local copy of Consul's docs/agent/http/agent.html.