### PR TITLE
Bump middleman to 3.4 as latest 3.3 was yanked

### DIFF
--- a/middleman-hashicorp.gemspec
+++ b/middleman-hashicorp.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '~> 2.0.0'
 
   # Middleman
-  spec.add_dependency 'middleman',             '~> 3.3'
+  spec.add_dependency 'middleman',             '~> 3.4'
   spec.add_dependency 'middleman-minify-html', '~> 3.4'
   spec.add_dependency 'middleman-livereload',  '~> 3.4'
   spec.add_dependency 'middleman-syntax',      '~> 2.0'


### PR DESCRIPTION
the hashicorp/consul website depends on this gem, but as middleman 3.3.13 was yanked trying to run the website locally has become impossible since bundler cannot resolve the dependency on it.