### PR TITLE
Add github_path method

### DIFF
--- a/lib/middleman-hashicorp/hashicorp.rb
+++ b/lib/middleman-hashicorp/hashicorp.rb
@@ -363,6 +363,17 @@ module Middleman
           parts.last.capitalize
         end
       end
+
+      #
+      # Return a page's path on GitHub, relative to its source
+      # repo's root directory.
+      # @param page [Middleman::Sitemap::Resource] a sitemap resource object
+      # @return [String] the page's path on GitHub, relative to the repo's root
+      # directory
+      #
+      def github_path(page)
+        'blob/master/' + page.source_file.match(/website.*/)[0]
+      end
     end
 
     #

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -7,7 +7,7 @@ class Middleman::HashiCorpExtension
     instance = Middleman::HashiCorpExtension.new(app, bintray_enabled: false)
     instance.app = app # unclear why this needs to be set after, but it must
 
-    it 'should return path/filename.extension for non-index files' do
+    it 'returns path/filename.extension for non-index files' do
       current_page = Middleman::Sitemap::Resource.new(
         app.sitemap,
         '/foo/security.html',

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -7,7 +7,7 @@ class Middleman::HashiCorpExtension
     instance = Middleman::HashiCorpExtension.new(app, bintray_enabled: false)
     instance.app = app # unclear why this needs to be set after, but it must
 
-    it 'returns path/filename.extension for non-index files' do
+    it 'returns path/filename.extension' do
       current_page = Middleman::Sitemap::Resource.new(
         app.sitemap,
         '/foo/security.html',

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+require 'middleman-hashicorp/hashicorp'
+
+class Middleman::HashiCorpExtension
+  describe 'page_source helper' do
+    app = middleman_app
+    instance = Middleman::HashiCorpExtension.new(app, bintray_enabled: false)
+    instance.app = app # unclear why this needs to be set after, but it must
+
+    it 'should return path/filename.extension for non-index files' do
+      current_page = Middleman::Sitemap::Resource.new(
+        app.sitemap,
+        '/foo/security.html',
+        '/some/series/of/directories/website/source/security.html.erb')
+      page_source = instance.app.github_path(current_page)
+      expect(page_source).to eql('blob/master/website/source/security.html.erb')
+    end
+  end
+end


### PR DESCRIPTION
For a given `Middleman::Sitemap::Resource` (which is what `current_page` returns), this method will return the path of its source file on GitHub, relative to the repository root. So if a `Resource` derives from `/some/series/of/directories/website/source/security.html.erb`, the method will return `blob/master/website/source/security.html.erb`. That way, it's easier to make links like `https://github.com/hashicorp/vault/<%= github_path current_page %>`.