### PR TITLE
github_url method

### DIFF
--- a/lib/middleman-hashicorp/hashicorp.rb
+++ b/lib/middleman-hashicorp/hashicorp.rb
@@ -376,7 +376,7 @@ module Middleman
       #
       def github_url(specificity = :repo)
         return false if github_slug.nil?
-        base_url = 'https://www.github.com/' + github_slug
+        base_url = "https://www.github.com/#{github_slug}"
         if specificity == :repo
           base_url
         elsif specificity == :current_page

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -15,6 +15,7 @@ class Middleman::HashiCorpExtension
     it "returns the project's GitHub URL if no argument is supplied" do
       expect(@instance.app.github_url).to match("https://www.github.com/hashicorp/this_project")
     end
+
     it "returns false if github_slug has not been set" do
       slugless_app = Middleman::Application.server.inst
       slugless_instance = Middleman::HashiCorpExtension.new(

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -2,18 +2,44 @@ require 'spec_helper'
 require 'middleman-hashicorp/hashicorp'
 
 class Middleman::HashiCorpExtension
-  describe 'page_source helper' do
-    app = middleman_app
-    instance = Middleman::HashiCorpExtension.new(app, bintray_enabled: false)
-    instance.app = app # unclear why this needs to be set after, but it must
+  describe '#github_url' do
+    before(:all) do
+      app = middleman_app
+      @instance = Middleman::HashiCorpExtension.new(
+        app,
+        bintray_enabled: false,
+        github_slug: 'hashicorp/this_project')
+      @instance.app = app # unclear why this needs to be set after, but it must
+    end
 
-    it 'returns path/filename.extension' do
+    it "returns the project's GitHub URL if no argument is supplied" do
+      expect(@instance.app.github_url).to match("https://www.github.com/hashicorp/this_project")
+    end
+    it "returns false if github_slug has not been set" do
+      slugless_app = Middleman::Application.server.inst
+      slugless_instance = Middleman::HashiCorpExtension.new(
+        slugless_app,
+        bintray_enabled: false)
+      slugless_instance.app = slugless_app
+      expect(slugless_instance.app.github_url).to eq(false)
+    end
+  end
+
+  describe "#path_in_repository" do
+    it "returns a resource's path relative to its source repository's root directory" do
+      app = middleman_app
+      instance = Middleman::HashiCorpExtension.new(
+        app,
+        bintray_enabled: false,
+        github_slug: 'hashicorp/this_project',
+        website_root: 'website')
+      instance.app = app
       current_page = Middleman::Sitemap::Resource.new(
-        app.sitemap,
-        '/foo/security.html',
-        '/some/series/of/directories/website/source/security.html.erb')
-      page_source = instance.app.github_path(current_page)
-      expect(page_source).to eql('blob/master/website/source/security.html.erb')
+        instance.app.sitemap,
+        'docs/index.html',
+        '/some/bunch/of/directories/website/source/docs/index.html.markdown')
+      path_in_repository = instance.app.path_in_repository(current_page)
+      expect(path_in_repository).to match('website/source/docs/index.html.markdown')
     end
   end
 end


### PR DESCRIPTION
This pull request replaces the `github_path` method with `github_url`. By default, the method returns the GitHub repository for a project (i.e. `https://github.com/hashicorp/vault`). When run with the `:current_page` argument, it returns a link to the GitHub page from which the current page was derived.

Note that the pull request introduces two new config variables to `middleman-hashicorp`:
* `github_slug` — the project's GitHub `namespace/project_name` duo (e.g. `hashicorp/serf`)
* `website_root` — the project's middleman directory relative to the Git root (typically `'website'`)

This should resolve #13.