### PR TITLE
Handle source_file/path mismatch in #path_in_repository method

### DIFF
--- a/lib/middleman-hashicorp/hashicorp.rb
+++ b/lib/middleman-hashicorp/hashicorp.rb
@@ -391,9 +391,9 @@ module Middleman
       # directory
       #
       def path_in_repository(resource)
-        repository_path = resource.path
-        file_extension = resource.source_file.split(resource.path)[1]
-        website_root + "/source/" + repository_path + file_extension
+        relative_path = resource.path.match(/.*\//).to_s
+        file = resource.source_file.split('/').last
+        website_root + "/source/" + relative_path + file
       end
     end
 

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -27,20 +27,36 @@ class Middleman::HashiCorpExtension
   end
 
   describe "#path_in_repository" do
-    it "returns a resource's path relative to its source repository's root directory" do
+    before(:each) do
       app = middleman_app
-      instance = Middleman::HashiCorpExtension.new(
+      @instance = Middleman::HashiCorpExtension.new(
         app,
         bintray_enabled: false,
-        github_slug: 'hashicorp/this_project',
-        website_root: 'website')
-      instance.app = app
-      current_page = Middleman::Sitemap::Resource.new(
-        instance.app.sitemap,
-        'docs/index.html',
-        '/some/bunch/of/directories/website/source/docs/index.html.markdown')
-      path_in_repository = instance.app.path_in_repository(current_page)
-      expect(path_in_repository).to match('website/source/docs/index.html.markdown')
+        github_slug: "hashicorp/this_project",
+        website_root: "website")
+      @instance.app = app
+    end
+
+    context "when a resource's path string is not within its source_file string" do
+      it "returns a resource's path relative to its source repository's root directory" do
+        current_page = Middleman::Sitemap::Resource.new(
+          @instance.app.sitemap,
+          "intro/examples/cross-provider.html",
+          "/some/bunch/of/directories/intro/examples/cross-provider.markdown")
+        path_in_repository = @instance.app.path_in_repository(current_page)
+        expect(path_in_repository).to match("website/source/intro/examples/cross-provider.markdown")
+      end
+    end
+
+    context "when a resource's path string lies within its source_file string" do
+      it "returns a resource's path relative to its source repository's root directory" do
+        current_page = Middleman::Sitemap::Resource.new(
+          @instance.app.sitemap,
+          "docs/index.html",
+          "/some/bunch/of/directories/website/source/docs/index.html.markdown")
+        path_in_repository = @instance.app.path_in_repository(current_page)
+        expect(path_in_repository).to match("website/source/docs/index.html.markdown")
+      end
     end
   end
 end


### PR DESCRIPTION
This PR changes the way we're figuring out `path_in_repository` to avoid assuming that a Resource's `path` will lie within its `source_file` string. This was causing trouble on the Terraform site, because the source file for https://terraform.io/intro/examples/cross-provider.html is `website/source/intro/examples/cross-provider.markdown`. 