### PR TITLE
Use bare github.com

### DIFF
--- a/lib/middleman-hashicorp/extension.rb
+++ b/lib/middleman-hashicorp/extension.rb
@@ -185,7 +185,7 @@ class Middleman::HashiCorpExtension < ::Middleman::Extension
     #
     def github_url(specificity = :repo)
       return false if github_slug.nil?
-      base_url = "https://www.github.com/#{github_slug}"
+      base_url = "https://github.com/#{github_slug}"
       if specificity == :repo
         base_url
       elsif specificity == :current_page

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -16,7 +16,7 @@ class Middleman::HashiCorpExtension
     end
 
     it "returns the project's GitHub URL if no argument is supplied" do
-      expect(@instance.app.github_url).to match("https://www.github.com/hashicorp/this_project")
+      expect(@instance.app.github_url).to match("https://github.com/hashicorp/this_project")
     end
 
     it "returns false if github_slug has not been set" do


### PR DESCRIPTION
In Terraform docs I noticed "Edit this page" URLs went to `www.github.com`. I usually only see the bare domain for GitHub. This is admittedly a minor cosmetic change but it makes my brain feel better.