### PR TITLE
Update anchor generation for multi-link list-items

### DIFF
--- a/lib/middleman-hashicorp/redcarpet.rb
+++ b/lib/middleman-hashicorp/redcarpet.rb
@@ -25,7 +25,7 @@ class Middleman::HashiCorp::RedcarpetHTML < ::Middleman::Renderers::MiddlemanRed
   #
   def list_item(text, list_type)
     md = text.match(/(<code>(.+?)<\/code>)/)
-    linked = !text.match(/<a(.+?)>(.+?)<\/a>/).nil?
+    linked = !text.match(/^(<p>)?<a(.+?)>(.+?)<\/a>\s*?[-:]?/).nil?
 
     if !md.nil? && !linked
       container, name = md.captures

--- a/spec/unit/markdown_spec.rb
+++ b/spec/unit/markdown_spec.rb
@@ -65,6 +65,7 @@ module Middleman::HashiCorp
         - [`/one`](#link_one): Some text
         - [`/two`](#link_two)
         - `three` is a regular auto-link
+        - [`/four`](#link_four) - Same as one but with a -
       EOH
       output = <<-EOH.gsub(/^ {8}/, "")
         <ul>
@@ -73,6 +74,30 @@ module Middleman::HashiCorp
         <li><a href="#link_two"><code>/two</code></a>
         </li>
         <li><a name="three" /><a href="#three"><code>three</code></a> is a regular auto-link
+        </li>
+        <li><a href="#link_four"><code>/four</code></a> - Same as one but with a -
+        </li>
+        </ul>
+      EOH
+
+      expect(markdown).to render_html(output)
+    end
+
+    it "adds links to unordered lists with unrelated content links" do
+      markdown = <<-EOH.gsub(/^ {8}/, "")
+        - `one`
+
+        - `two` - has a [link_two](#link_two) inside
+
+        - `three`: is regular but with a colon
+      EOH
+      output = <<-EOH.gsub(/^ {8}/, "")
+        <ul>
+        <li><p><a name="one" /><a href="#one"><code>one</code></a></p>
+        </li>
+        <li><p><a name="two" /><a href="#two"><code>two</code></a> - has a <a href="#link_two">link_two</a> inside</p>
+        </li>
+        <li><p><a name="three" /><a href="#three"><code>three</code></a>: is regular but with a colon</p>
         </li>
         </ul>
       EOH


### PR DESCRIPTION
This looks related to #6.

The problem I'm seeing is that terraform's documentation will sometimes contain list items with an `<a>` tag within the description of a `<li>`. The previous regex would find that there was a link within the `<li>` already, and then refuse to generate the anchor at the beginning of the `<li>`, which made it hard for me to paste docs links to people in IRC :(.

For an example of this, see the `file(path)` list-item on [this page](https://www.terraform.io/docs/configuration/interpolation.html)

I also added some tests for this case.

The regex would probably be nicer if there was a set standard across all Hashicorp docs. I did some poking around and couldn't seem to find one, so I'm hoping this is the least invasive way of getting this to work again!