### PR TITLE
markdown: set toc data

### DIFF
--- a/lib/middleman-hashicorp/extension.rb
+++ b/lib/middleman-hashicorp/extension.rb
@@ -62,6 +62,8 @@ class Middleman::HashiCorpExtension < ::Middleman::Extension
     app.set :github_slug, options.github_slug
     app.set :website_root, options.website_root
 
+    app.set :markdown, with_toc_data: true
+
     # Configure the development-specific environment
     app.configure :development do
       # Reload the browser automatically whenever files change


### PR DESCRIPTION
It appears passing the redcarpet options hash isn't working as-is but
this enabled TOC data.

cc/ @sethvargo