### PR TITLE
releases: Allow graceful degradation in offline mode

### DIFF
--- a/lib/middleman-hashicorp/releases.rb
+++ b/lib/middleman-hashicorp/releases.rb
@@ -7,10 +7,19 @@ class Middleman::HashiCorp::Releases
 
   def self.fetch(product, version)
     url = "#{RELEASES_URL}/#{product}/#{version}/index.json"
-    r = JSON.parse(open(url).string,
-      create_additions: false,
-      symbolize_names: true,
-    )
+    begin
+      resp = open(url)
+      r = JSON.parse(resp.string,
+        create_additions: false,
+        symbolize_names: true,
+      )
+    rescue SocketError
+      # Allow offline development for docs pages etc.
+      r = {
+        :builds => []
+      }
+      warn "WARNING: Unable to fetch latest releases for #{product} #{version} (SocketError)"
+    end
 
     # Convert the builds into the following format:
     #

--- a/spec/unit/releases_spec.rb
+++ b/spec/unit/releases_spec.rb
@@ -18,6 +18,19 @@ describe Middleman::HashiCorp::Releases do
     end
   end
 
+  context "when there is no internet connection" do
+    expected_url = "https://releases.hashicorp.com/terraform/0.6.16/index.json"
+    expected_warn_msg = "WARNING: Unable to fetch latest releases for terraform 0.6.16 (SocketError)\n"
+
+    it "fails gracefully with a warning" do
+      expect(described_class).to receive(:open).with(expected_url).and_raise(SocketError)
+
+      expect {
+        described_class.fetch("terraform", "0.6.16")
+      }.to output(expected_warn_msg).to_stderr
+    end
+  end
+
   it "returns the JSON representation of the version" do
     r = described_class.fetch("consul", "0.1.0")
     expect(r["darwin"]).to eq(


### PR DESCRIPTION
This caught me out couple days ago when I wanted to do some work on Terraform docs on an airplane (offline).

Before (from `hashicorp/terraform//website`):

```
$ bundle exec middleman
```
```
== The Middleman is loading
/Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:879:in `initialize': getaddrinfo: nodename nor servname provided, or not known (SocketError)
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:879:in `open'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:879:in `block in connect'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/timeout.rb:74:in `timeout'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:878:in `connect'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:863:in `do_start'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/net/http.rb:852:in `start'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/open-uri.rb:318:in `open_http'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/open-uri.rb:736:in `buffer_open'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/open-uri.rb:211:in `block in open_loop'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/open-uri.rb:209:in `catch'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/open-uri.rb:209:in `open_loop'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/open-uri.rb:150:in `open_uri'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/open-uri.rb:716:in `open'
	from /Users/radek/.rbenv/versions/2.2.2/lib/ruby/2.2.0/open-uri.rb:34:in `open'
```

After:
```
== The Middleman is loading
WARNING: Unable to fetch latest releases for terraform 0.6.16 (SocketError)
/Users/radek/.rbenv/versions/2.2.2/lib/ruby/gems/2.2.0/gems/middleman-livereload-3.4.6/lib/middleman-livereload/reactor.rb:14: warning: toplevel constant Mutex referenced by Thread::Mutex
== LiveReload accepting connections from ws://172.16.10.1:35729
== View your site at "http://localhost:4567", "http://127.0.0.1:4567"
== Inspect your site configuration at "http://localhost:4567/__middleman", "http://127.0.0.1:4567/__middleman"
```

The downloads section looks like this (in offline mode):

<img width="1122" alt="screen shot 2016-06-18 at 12 58 24" src="https://cloud.githubusercontent.com/assets/287584/16170983/172f392a-355c-11e6-9c26-24d1a2e1c371.png">
