### PR TITLE
Link and hover style

### DIFF
--- a/assets/stylesheets/hashicorp/mega-nav.scss
+++ b/assets/stylesheets/hashicorp/mega-nav.scss
@@ -110,6 +110,16 @@ $mega-nav-sandbox-specificity:          4;
       color: $mega-nav-color-neutral;
     }
 
+    .mega-nav-banner-logo {
+      opacity: 1;
+
+      &:hover {
+        opacity: 0.7;
+        transition: opacity .25s ease-in-out;
+        -moz-transition: opacity .25s ease-in-out;
+        -webkit-transition: opacity .25s ease-in-out;
+      }
+    }
   }
 
     .mega-nav-banner-item {
@@ -432,6 +442,11 @@ $mega-nav-sandbox-specificity:          4;
   }
 
   @media (min-width: $mega-nav-breakpoint-sm) {
+    .mega-nav-banner-item {
+      &:first-child {
+        display: block;
+      }
+    }
 
     .mega-nav-btn {
       margin-bottom: mega-nav-em($mega-nav-line-height-base * 2, $mega-nav-btn-font-size);
@@ -532,12 +547,6 @@ $mega-nav-sandbox-specificity:          4;
   }
 
   @media (min-width: $mega-nav-breakpoint-md) {
-
-    .mega-nav-banner-item {
-      &:first-child {
-        display: block;
-      }
-    }
 
     .mega-nav {
       position: relative;

--- a/lib/middleman-hashicorp/partials/_mega.html.erb
+++ b/lib/middleman-hashicorp/partials/_mega.html.erb
@@ -12,7 +12,7 @@
   <div class="mega-nav-banner">
     <div class="container">
       <div class="mega-nav-banner-item">
-        <img src="<%= image_path("mega-nav/logo-hashicorp-wordmark.svg") %>" alt="HashiCorp Logo" />
+        <a class="mega-nav-banner-logo" href="https://www.hashicorp.com"><img src="<%= image_path("mega-nav/logo-hashicorp-wordmark.svg") %>" alt="HashiCorp Logo" /></a>
       </div>
       <div class="mega-nav-banner-item">
         <p class="mega-nav-tagline"><span class="visible-xs text-muted">Learn the</span><span class="hidden-xs text-muted">Learn how <%= product.titleize %> fits into the</span> <img src="<%= image_path("mega-nav/logo-hashicorp.svg") %>" alt="HashiCorp Logo" /> <strong>HashiCorp Suite</strong></p>


### PR DESCRIPTION
Just a small PR to link the HashiCorp logo to the homepage. The hover style lowers opacity to 70%, which we commonly do for the logos on the OSS sites.

cc @gawinowicz 