### PR TITLE
move display logo to 768px

### DIFF
--- a/assets/stylesheets/hashicorp/mega-nav.scss
+++ b/assets/stylesheets/hashicorp/mega-nav.scss
@@ -536,16 +536,18 @@ $mega-nav-sandbox-specificity:          4;
     .mega-nav-btn {
       width: auto;
     }
-
   }
 
-  @media (min-width: $mega-nav-breakpoint-md) {
-
+  // Display HashiCorp logo at Bootstrap breakpoint of 768px
+  @media (min-width: 768px){
     .mega-nav-banner-item {
       &:first-child {
         display: block;
       }
     }
+  }
+
+  @media (min-width: $mega-nav-breakpoint-md) {
 
     .mega-nav {
       position: relative;


### PR DESCRIPTION
Mega Nav currently displays the HashiCorp logomark at 992px. This moves the declaration to show the element to a 768px breakpoint, keeping the logo visible until the condensed layout changes at the 768 breakpoint. 

cc/ @sethvargo @gawinowicz 