### PR TITLE
Add linkable headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Customizations
 - During build, assets are hashed
 - During build, gzipped assets are also created
 
-### IE Compatibility 
+### IE Compatibility
 
 There are bundled things that make IE behave nicely. Include them like this:
 
@@ -145,7 +145,7 @@ This extension extends the redcarpet markdown processor to add some additional f
 In addition to "standard markdown", the custom markdown parser supports the following:
 
 #### Auto-linking Anchor Tags
-Sine the majority of HashiCorp's projects use the following syntax to define APIs, this extension automatically converts those to named anchor links:
+Since the majority of HashiCorp's projects use the following syntax to define APIs, this extension automatically converts those to named anchor links:
 
 ```markdown
 - `api_method` - description
@@ -157,6 +157,15 @@ Outputs:
 <ul>
   <li><a name="api_method" /><a href="#api_method"></a> - description</li>
 </ul>
+```
+
+#### Auto-linking Header Tags
+
+Header links will automatically generate linkable hrefs on hover. This can be used to easily link to sub-sections of a page. This _requires_ the following SCSS.
+
+```scss
+// assets/stylesheets/application.scss
+@import 'hashicorp/anchor-links'
 ```
 
 Any special characters are converted to an underscore (`_`).

--- a/assets/stylesheets/hashicorp/anchor-links.scss
+++ b/assets/stylesheets/hashicorp/anchor-links.scss
@@ -1,0 +1,36 @@
+//
+// Anchor links must be included to hide/auto-show anchor links.
+//
+
+h1 {
+  .anchor {
+    display: none;
+  }
+}
+
+h2,
+h3,
+h4,
+h5,
+h6 {
+  .anchor {
+    color: inherit !important;
+    float: left;
+    margin-left: -15px;
+    padding-right: 5px;
+    line-height: 1.1;
+    text-decoration: none !important;
+    visibility: hidden;
+
+    &:focus {
+      outline: none;
+    }
+  }
+
+  &:hover {
+    .anchor {
+      text-decoration: none !important;
+      visibility: visible;
+    }
+  }
+}

--- a/lib/middleman-hashicorp/redcarpet.rb
+++ b/lib/middleman-hashicorp/redcarpet.rb
@@ -22,6 +22,30 @@ class Middleman::HashiCorp::RedcarpetHTML < ::Middleman::Renderers::MiddlemanRed
   end
 
   #
+  # Override headers to add custom links.
+  #
+  def header(title, level)
+    @headers ||= {}
+
+    name = title.downcase.strip.gsub(/\W+/, '-').gsub(/\A\-/, '')
+
+    i = 0
+    permalink = name
+    while @headers.key?(permalink) do
+      i += 1
+      permalink = "#{name}-#{i}"
+    end
+    @headers[permalink] = true
+
+    return <<-EOH.gsub(/^ {6}/, "")
+      <h#{level} id="#{permalink}">
+        <a name="#{permalink}" class="anchor" href="##{permalink}">&raquo;</a>
+        #{title}
+      </h#{level}>
+    EOH
+  end
+
+  #
   # Override list_item to automatically add links for documentation
   #
   # @param [String] text

--- a/spec/unit/markdown_spec.rb
+++ b/spec/unit/markdown_spec.rb
@@ -202,11 +202,21 @@ module Middleman::HashiCorp
       markdown = <<-EOH.gsub(/^ {8}/, "")
         # Hello World
         ## Subpath
+        ## Subpath
       EOH
       output = <<-EOH.gsub(/^ {8}/, "")
-        <h1 id="hello-world">Hello World</h1>
-
-        <h2 id="subpath">Subpath</h2>
+        <h1 id="hello-world">
+          <a name="hello-world" class="anchor" href="#hello-world">&raquo;</a>
+          Hello World
+        </h1>
+        <h2 id="subpath">
+          <a name="subpath" class="anchor" href="#subpath">&raquo;</a>
+          Subpath
+        </h2>
+        <h2 id="subpath-1">
+          <a name="subpath-1" class="anchor" href="#subpath-1">&raquo;</a>
+          Subpath
+        </h2>
       EOH
 
       expect(markdown).to render_html(output)


### PR DESCRIPTION
This adds auto-linking to `<hn>` tags. We already had linking, but this adds a clickable element on hover for users to do their own linking. This will only apply on pages that use markdown, so "homepages" will be unaffected.