### PR TITLE
Ignore asset hashing for assets/files

### DIFF
--- a/lib/middleman-hashicorp/extension.rb
+++ b/lib/middleman-hashicorp/extension.rb
@@ -78,7 +78,7 @@ class Middleman::HashiCorpExtension < ::Middleman::Extension
       end
 
       # Enable cache buster
-      activate :asset_hash
+      activate :asset_hash, :ignore => [/^assets\/files\//]
     end
   end
 


### PR DESCRIPTION
We need a static URL (which doesn't change with every website release) for a logo, so we can link it reliably from our Terraform Readme-s.

The Github raw URLs don't seem to be stable for some reason and images keep disappearing from Readme-s.

This change should not affect any website as we only store `press-kit.zip` in such location which isn't hashed anyway (b/c it has zip extension):

https://github.com/hashicorp/consul/tree/master/website/source/assets/files
https://github.com/hashicorp/terraform-website/tree/master/content/source/assets/files
https://github.com/hashicorp/nomad/tree/master/website/source/assets/files
https://github.com/hashicorp/vault/tree/master/website/source/assets/files
https://github.com/mitchellh/vagrant/tree/master/website/source/assets/files
https://github.com/hashicorp/packer/tree/master/website/source/assets/files

TL;DR We need `https://www.terraform.io/assets/files/terraform-logo.svg` , _not_ `https://www.terraform.io/assets/files/terraform-logo-3f10732f.svg`