### PR TITLE
Remove the unindent for nested Markdown

### DIFF
--- a/lib/middleman-hashicorp/redcarpet.rb
+++ b/lib/middleman-hashicorp/redcarpet.rb
@@ -69,7 +69,7 @@ class Middleman::HashiCorp::RedcarpetHTML < ::Middleman::Renderers::MiddlemanRed
 
     if md = raw.match(/\<(.+?)\>(.*)\<(\/.+?)\>/m)
       open_tag, content, close_tag = md.captures
-      "<#{open_tag}>\n#{recursive_render(unindent(content))}<#{close_tag}>"
+      "<#{open_tag}>\n#{recursive_render(content)}<#{close_tag}>"
     else
       raw
     end

--- a/spec/unit/markdown_spec.rb
+++ b/spec/unit/markdown_spec.rb
@@ -167,6 +167,31 @@ module Middleman::HashiCorp
       expect(markdown).to render_html(output)
     end
 
+    it "does not unindent recursive markdown code blocks" do
+      markdown = <<-EOH.gsub(/^ {8}/, "")
+        <div class="examples">
+          <div class="examples-body">
+            ```python
+            a
+              b
+                c
+            ```
+          </div>
+        </div>
+      EOH
+      output = <<-EOH.gsub(/^ {8}/, "")
+        <div class="examples">
+        <div class="examples-body">
+        <pre><code class="python">a
+          b
+            c
+        </code></pre>
+        </div></div>
+      EOH
+
+      expect(markdown).to render_html(output)
+    end
+
     it "supports alert boxes" do
       markdown = <<-EOH.gsub(/^ {8}/, "")
         => This is a success note


### PR DESCRIPTION
When nesting a Markdown code block, the leading whitespace was stripped regardless of the context.

Example of what is was doing before:

![](http://c.justincampbell.me/221t0N1K0Y3z/Screen%20Shot%202017-10-20%20at%201.37.25%20PM.png)
![](http://c.justincampbell.me/2A1R07372g2M/Screen%20Shot%202017-10-20%20at%201.36.42%20PM.png)