### PR TITLE
Add analytics helper scripts

### DIFF
--- a/assets/javascripts/hashicorp/analytics.js
+++ b/assets/javascripts/hashicorp/analytics.js
@@ -1,0 +1,37 @@
+/**
+ * Wrapper for segment's track function that will track multiple elements,
+ * normalize parameters, and easily switch between tracking links or events.
+ * @param  {String} selector - query selector, multi element compatible
+ * @param  {Function} cb - optional function that should return params, and will receive the element as a parameter
+ * @param  {Boolean} [link=false] - if true, tracks a link click
+ */
+function track(selector, cb, link = false) {
+  each(document.querySelectorAll(selector), el => {
+    var params = cb
+    if (typeof cb === 'function') params = cb(el)
+    var event = params.event
+    delete params.event
+    if (link) {
+      analytics.trackLink(el, event, params)
+    } else {
+      el.addEventListener('click', function() {
+        analytics.track(event, params)
+      })
+    }
+  })
+}
+
+/**
+ * Iterates through a NodeList, not built-in for all browsers.
+ * (https://developer.mozilla.org/en-US/docs/Web/API/NodeList)
+ * @param  {NodeList} list a NodeList instance
+ * @param  {Function} cb a function to execute for each node
+ */
+function each(list, cb) {
+  for (let i = 0; i < list.length; i++) cb(list[i], i)
+}
+
+// Expose as commonjs for module bundlers if needed
+if (module && module.exports) {
+  module.exports = { track }
+}


### PR DESCRIPTION
We are working on updating open source sites to track with segment, this helper makes the code a lot smoother and easier. Once all OSS sites are moved over to the new framework, this script will probably be moved to an externally consumed global script, published likely out of the web-components repo. But until then, this should do the trick as far as greatly reducing repetition across OSS properties.