### PR TITLE
remove --squash option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ docker:
 	@echo "==> Building container v${VERSION}..."
 	@docker build \
 		--file "docker/Dockerfile" \
-		--squash \
 		--tag "hashicorp/middleman-hashicorp" \
 		--tag "hashicorp/middleman-hashicorp:${VERSION}" \
 		--pull \


### PR DESCRIPTION
docker build `--squash` is an experimental option and it works poorly with CI or locally if you don't have experimental features turned on. 