### PR TITLE
get middleman-hashicorp gem from rubygem instead of local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ docker:
 	@echo "==> Building container v${VERSION}..."
 	@docker build \
 		--file "docker/Dockerfile" \
+		--build-arg GEM_VERSION=${VERSION} \
 		--tag "hashicorp/middleman-hashicorp" \
 		--tag "hashicorp/middleman-hashicorp:${VERSION}" \
 		--pull \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,8 @@
 FROM ruby:2.3-alpine
 MAINTAINER Seth Vargo <seth@hashicorp.com>
 
+ARG GEM_VERSION
+
 # Install packages
 RUN apk add --no-cache bash build-base curl jq nodejs python py-setuptools wget git
 
@@ -13,19 +15,12 @@ RUN cd /tmp && \
   cd .. && \
   rm -rf s3cmd-1.6.1*
 
-# Add the context
-ADD pkg/ /pkg
-
 # Upgrade bundler
 RUN gem update --no-document && \
   gem cleanup
 
 # Install the bundle
-RUN gem install /pkg/middleman-hashicorp-*.gem --no-document \
-  && rm -rf /pkg
-
-# Remove the package
-RUN rm -rf /pkg
+RUN gem install middleman-hashicorp -v ${GEM_VERSION} --no-document
 
 # Mounts
 WORKDIR /website


### PR DESCRIPTION
As discussed with @phinze and @jfreda this will make it more of a pipeline build as there should be a 1:1 correlation between what is in Rubygems and what is released in Docker hub. If there is no gem in Rubygems, the docker build should fail as well. 