### PR TITLE
Remove es6 artifact

### DIFF
--- a/assets/javascripts/hashicorp/analytics.js
+++ b/assets/javascripts/hashicorp/analytics.js
@@ -6,9 +6,11 @@
  * @param  {Boolean} [link=false] - if true, tracks a link click
  */
 function track(selector, cb, link = false) {
-  each(document.querySelectorAll(selector), el => {
+  each(document.querySelectorAll(selector), function(el) {
     var params = cb
-    if (typeof cb === 'function') params = cb(el)
+    if (typeof cb === 'function') {
+      params = cb(el)
+    }
     var event = params.event
     delete params.event
     if (link) {


### PR DESCRIPTION
The current OSS sites have a middleman setup that can't handle es6 code - I forgot to remove this one little piece which is preventing compilation.