### PR TITLE
Update supported values for pretty_os

### DIFF
--- a/lib/middleman-hashicorp/extension.rb
+++ b/lib/middleman-hashicorp/extension.rb
@@ -154,14 +154,16 @@ class Middleman::HashiCorpExtension < ::Middleman::Extension
     def pretty_os(os)
       case os
       when /darwin/
-        "Mac OS X"
+        "macOS"
       when /freebsd/
         "FreeBSD"
       when /openbsd/
         "OpenBSD"
       when /netbsd/
         "NetBSD"
-      when /linux/
+      when /archlinux/
+        "Arch Linux"
+      when "linux"
         "Linux"
       when /windows/
         "Windows"

--- a/lib/middleman-hashicorp/extension.rb
+++ b/lib/middleman-hashicorp/extension.rb
@@ -153,19 +153,19 @@ class Middleman::HashiCorpExtension < ::Middleman::Extension
     #
     def pretty_os(os)
       case os
-      when /darwin/
+      when "darwin"
         "macOS"
-      when /freebsd/
+      when "freebsd"
         "FreeBSD"
-      when /openbsd/
+      when "openbsd"
         "OpenBSD"
-      when /netbsd/
+      when "netbsd"
         "NetBSD"
-      when /archlinux/
+      when "archlinux"
         "Arch Linux"
       when "linux"
         "Linux"
-      when /windows/
+      when "windows"
         "Windows"
       else
         os.capitalize

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -93,4 +93,32 @@ class Middleman::HashiCorpExtension
       end
     end
   end
+
+  describe "#pretty_os" do
+    before(:each) do
+      app = middleman_app
+      @instance = Middleman::HashiCorpExtension.new(app,
+        releases_enabled: false,
+      )
+      @instance.app = app
+    end
+
+    [
+      ["darwin", "macOS"],
+      ["freebsd", "FreeBSD"],
+      ["openbsd", "OpenBSD"],
+      ["netbsd", "NetBSD"],
+      ["archlinux", "Arch Linux"],
+      ["linux", "Linux"],
+      ["windows", "Windows"],
+    ].each do |given, expected|
+      it "converts #{given} to #{expected}" do
+        expect(@instance.app.pretty_os(given)).to eq(expected)
+      end
+    end
+
+    it "should capitalize unknown OS" do
+      expect(@instance.app.pretty_os("hashicorplinux")).to eq("Hashicorplinux")
+    end
+  end
 end


### PR DESCRIPTION
Adds entry to properly format "archlinux" to "Arch Linux". Also
updates the linux match to only match on the explicit string, not
any value containing linux. This will prevent cases where a name
may not be defined (like archlinux) and it being displayed simply
as "Linux".

Also updated the pretty version of "darwin" to "macOS" since this
has been the official name since the Sierra release (2016).