### PR TITLE
Discard processed HTML if content is only wrapped in a paragraph

### DIFF
--- a/lib/middleman-hashicorp/redcarpet.rb
+++ b/lib/middleman-hashicorp/redcarpet.rb
@@ -69,10 +69,15 @@ class Middleman::HashiCorp::RedcarpetHTML < ::Middleman::Renderers::MiddlemanRed
 
     if md = raw.match(/\<(.+?)\>(.*)\<(\/.+?)\>/m)
       open_tag, content, close_tag = md.captures
-      "<#{open_tag}>\n#{recursive_render(content)}<#{close_tag}>"
-    else
-      raw
+      rendered_content = recursive_render(content)
+      # If the recursive render did more than simply wrap
+      # the content within a paragraph, assume this is valid
+      # markdown content and return the result
+      if rendered_content != paragraph(content)
+        return "<#{open_tag}>\n#{rendered_content}<#{close_tag}>"
+      end
     end
+    raw
   end
 
   #


### PR DESCRIPTION
If there is no markdown content to be updated within the HTML
block the result will be the content wrapped with `<p>` tags. When
the rendered result is just the content wrapped in `<p>` tags,
assume no markdown content was found and return original value.
This prevents double processing happening in cases where a
partial may be used.