### PR TITLE
Support for obtaining the latest release number for a Provider

### DIFF
--- a/lib/middleman-hashicorp/latest_release.rb
+++ b/lib/middleman-hashicorp/latest_release.rb
@@ -1,0 +1,28 @@
+require "json"
+require "open-uri"
+require "net/http"
+
+class Middleman::HashiCorp::LatestRelease
+
+  def self.fetch(product)
+    url = "https://releases.hashicorp.com/#{product}/index.json"
+    req = open(url)
+    body = req.read
+
+    r = JSON.parse(body,
+      create_additions: false,
+      symbolize_names: true,
+    )
+
+    versions = []
+    r[:versions].each do |ver|
+      v = Hash[ver[1]]
+      version = v[:version]
+      versions << version
+    end
+
+    sortedVersions = versions.sort_by(&Gem::Version.method(:new))
+    puts sortedVersions.last
+  end
+
+end


### PR DESCRIPTION
Full-disclosure: I don't know Middleman well enough to confirm if this is the right approach or not (and I'm unsure how's best to test this works). I've ported this from the following Ruby script based on `./lib/middleman-hashicorp/releases.rb`:

```ruby
require "json"
require "open-uri"
require "net/http"

def ProviderVersion(product)
  url = "https://releases.hashicorp.com/#{product}/index.json"
  req = open(url)
  body = req.read

  r = JSON.parse(body,
    create_additions: false,
    symbolize_names: true,
  )

  versions = []
  r[:versions].each do |ver|
    v = Hash[ver[1]]
    version = v[:version]
    versions << version
  end

  sortedVersions = versions.sort_by(&Gem::Version.method(:new))
  puts sortedVersions.last
end

ProviderVersion("terraform-provider-azurerm")
```

This should allow us to output the latest version of a product (such as a Provider) in the website (e.g. such as in the Provider docs) using a helper method like so:

```
provider "azurerm" {
  version = "=<%= latest_provider_version("azurerm") %>
}
```