### PR TITLE
Update sprockets gem to resolve security vulnerability

### DIFF
--- a/lib/middleman-hashicorp/version.rb
+++ b/lib/middleman-hashicorp/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module HashiCorp
-    VERSION = "0.3.37"
+    VERSION = "0.3.38"
   end
 end

--- a/middleman-hashicorp.gemspec
+++ b/middleman-hashicorp.gemspec
@@ -30,6 +30,9 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'builder',        '~> 3.2'
   spec.add_dependency 'redcarpet',      '~> 3.3'
 
+  # [CVE-2018-3760] Path Traversal in Sprockets: https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k
+  spec.add_dependency 'sprockets',      '~> 2.12.5'
+
   # Turbolinks
   spec.add_dependency 'turbolinks', '~> 5.0'
 


### PR DESCRIPTION
The version of sprockets we were using (`2.12.4`) was reported to have a
vulnerability.
https://groups.google.com/forum/#!topic/ruby-security-ann/2S9Pwz2i16k