### PR TITLE
Version bump to grab dependency updates / Add ToC to readme

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ branches:
     - master
 
 before_install:
-  - gem update bundler
+  - "gem install bundler -v '~> 1.13'"
 
 bundler_args: --jobs 7

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 A wrapper around [Middleman][] for HashiCorp's customizations.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Customizations](#customizations)
+- [Publishing a new Release](#publishing-a-new-release)
+- [Contributing](#contributing)
+
 ## Installation
 
 Add this line to the Gemfile:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ RUN cd /tmp && \
   rm -rf s3cmd-1.6.1*
 
 # Upgrade bundler
-RUN gem update --no-document && \
+RUN gem install bundler -v '~> 1.13' --no-document && \
   gem cleanup
 
 # Install the bundle

--- a/lib/middleman-hashicorp/version.rb
+++ b/lib/middleman-hashicorp/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module HashiCorp
-    VERSION = "0.3.38"
+    VERSION = "0.3.39"
   end
 end

--- a/lib/middleman-hashicorp/version.rb
+++ b/lib/middleman-hashicorp/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module HashiCorp
-    VERSION = "0.3.39"
+    VERSION = "0.3.38"
   end
 end

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -132,7 +132,7 @@ class Middleman::HashiCorpExtension
     end
 
     it "returns the latest provider version for a given provider" do
-      expect(@instance.app.latest_provider_version("template")).to eq("1.0.0")
+      expect(@instance.app.latest_provider_version("template")).to match(/\d+\.\d+\.\d+/)
     end
   end
 end


### PR DESCRIPTION
This is a version bump to capture dependency updates - see this [Slack conversation](https://hashicorp.slack.com/archives/C5FSPUGDS/p1553043138109800) for context.

Also adds a simple table of contents to `readme` as I missed the section on publishing a new release, and hopefully the ToC helps a future me having to ask an unnecessary question.