### PR TITLE
Waste less time on every command by including all dependencies in Docker build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN gem install bundler -v '~> 1.13' --no-document && \
   gem cleanup
 
 # Install the bundle
-RUN GEM_PATH=$GEM_HOME gem install middleman-hashicorp -v ${GEM_VERSION} --no-document
+RUN GEM_PATH="${GEM_HOME}" gem install middleman-hashicorp -v "${GEM_VERSION}" --no-document
 
 # Mounts
 WORKDIR /website

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ RUN gem install bundler -v '~> 1.13' --no-document && \
   gem cleanup
 
 # Install the bundle
-RUN gem install middleman-hashicorp -v ${GEM_VERSION} --no-document
+RUN GEM_PATH=$GEM_HOME gem install middleman-hashicorp -v ${GEM_VERSION} --no-document
 
 # Mounts
 WORKDIR /website

--- a/lib/middleman-hashicorp/version.rb
+++ b/lib/middleman-hashicorp/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module HashiCorp
-    VERSION = "0.3.38"
+    VERSION = "0.3.39"
   end
 end


### PR DESCRIPTION
Once this is merged, I'll tag f6144f4 (the commit with the Dockerfile change) as v0.3.39.

This PR appeases Bundler by installing all dependencies in GEM_HOME, so that it won't pointlessly re-install gems every time you run a command in the container.

## Detailed explanation

We install the middleman-hashicorp gem with a normal `gem install`; no fancy
Bundler stuff.

Gem's normal behavior is to allow installed gems from anywhere in the GEM_PATH
to satisfy dependencies for the thing you're installing, and the base image has
several things that middleman-hashicorp depends on.

Bundler seems to be _mostly_ OK with using those same installed gems to satisfy
dependencies, EXCEPT for a few random special gems (Rack and Minitest) that it
insists on installing its own copies of! For some baffling reason!!! (Is it
because they have a binary installed somewhere outside bundle exec's PATH? But
that wouldn't explain minitest...) Even if you change Gemfile.lock to specify
the locally-installed versions, it will always re-install them when you start
the container. That means _every_ command you run has an unnecessary call to the
rubygems server and an unnecessary download and install of the affected gems.

So instead of trying to figure out what Bundler's damage is, let's just do what
it wants and make sure `gem install` re-installs all of our dependencies into
the expected place. We can do that by just temporarily blinding gem to the rest
of the GEM_PATH, so it doesn't see any of the already installed dependencies.
Setting an env var before a command like this ensures it won't affect any future
commands run in the container.

Have tested this with a local docker build and confirmed that I can start the
resulting container without any extraneous gem installs. 👍🏼 🙌🏼 💪🏼😤