### PR TITLE
bump version to 0.3.42 for next release

### DIFF
--- a/lib/middleman-hashicorp/version.rb
+++ b/lib/middleman-hashicorp/version.rb
@@ -1,5 +1,5 @@
 module Middleman
   module HashiCorp
-    VERSION = "0.3.41"
+    VERSION = "0.3.42"
   end
 end


### PR DESCRIPTION
Releasing 0.3.41 as a no-op version just to get a Nokogiri update into the Docker container. cf. https://nvd.nist.gov/vuln/detail/CVE-2019-5477