### PR TITLE
Switch to Dockerhub mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   ruby:
     docker:
-      - image: circleci/ruby:2.3.4-node
+      - image: docker.mirror.hashicorp.services/circleci/ruby:2.3.4-node
 
 commands:
   bundle-dependencies:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3-alpine
+FROM docker.mirror.hashicorp.services/ruby:2.3-alpine
 MAINTAINER Seth Vargo <seth@hashicorp.com>
 
 ARG GEM_VERSION


### PR DESCRIPTION
Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. circleci/cimg images are excluded. 